### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.14.0-rc1

### DIFF
--- a/star-plugins/star-sql-plugin/pom.xml
+++ b/star-plugins/star-sql-plugin/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.14.0-rc1</version>
         </dependency>
         <dependency>
             <groupId>org.lz4</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.10.0
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.10.0 to 2.14.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS